### PR TITLE
[Fix] system url function show html entities in notifications

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -87,7 +87,7 @@ function url($parameters, $mergeParameters = false, $useCurrentUrl = true) {
 			}
 		}
 
-		$result .= ($useCurrentUrl ? $url['path'] ?? '' : '') . ($parameters ? '?' . urldecode(http_build_query($parameters)) : '');
+		$result .= ($useCurrentUrl ? $url['path'] ?? '' : '') . ($parameters ? '?' . http_build_query($parameters) : '');
 	}
 
 	return  $result;


### PR DESCRIPTION
See Notification Tag saved in french
Bug: Tag enregistr&eacute;&nbsp;!

![Screenshot 2025-06-03 at 01-36-36 Vvveb - Notification Tag saved html entities error](https://github.com/user-attachments/assets/c55c43d2-36d6-43b8-9cbb-4d68b1c5638a)

Fix: Tag enregistré !

![Screenshot 2025-06-03 at 01-39-05 Vvveb - Notification Tag saved html entities Fix OK](https://github.com/user-attachments/assets/5fb90f15-f760-438d-abbc-cb575c0f2053)

Sometime less is more... & Think K.I.S.S.

> Note: not fully tested with all marvelous possibilities of Vvveb...
I share this commit just in case.

N.B.:

Tested to replace `urldecode`  with `urlencode` but fail in numerous link (edit/design btns) 

