### PR TITLE
[Fix] system functions sanitizeFileName for uf8 filename [PHP>=8]

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -1003,14 +1003,12 @@ function sanitizeFileName($file) {
 	if (! $file) {
 		return $file;
 	}
+	$file = explode(DIRECTORY_SEPARATOR, $file);
+	$filename = end($file);
+	$filename = preg_replace("/[^\p{L}\p{N}\s\-_'’.]/u", '', trim(html_entity_decode($filename, ENT_QUOTES, 'UTF-8')));
+	$file[array_key_last($file)] = $filename;
 
-	//sanitize, remove double dot .. and remove get parameters if any
-	$file = preg_replace('@\?.*$|\.{2,}|[^\/\\a-zA-Z0-9\-\._]@' , '', $file);
-	$file = preg_replace('@[^\/\w\s\d\.\-_~,;:\[\]\(\)\\]|[\.]{2,}@', '', $file);
-	//replace directory separators with OS specific separator
-	$file = str_replace(['\\', '/'], DS, $file);
-
-	return $file;
+	return implode(DIRECTORY_SEPARATOR, $file);
 }
 
 function formatBytes($bytes) {


### PR DESCRIPTION
Fix accentuated upload filename

<details>

<summary>

### Screenshots

</summary>

#### Before:

![Screenshot 2025-06-03 at 16-30-32 Vvveb - Media - ACCENTUATED - ERROR - upload](https://github.com/user-attachments/assets/d7e1e141-6c0d-4d7d-aa61-0f2ec4ec739a)

#### After fix:

![Screenshot 2025-06-03 at 16-30-32 Vvveb - Media - ACCENTUATED - FIX - upload](https://github.com/user-attachments/assets/8694755a-9bdf-4683-8fdb-318b7ca0818b)


---

</details>

Note: [From upload controller of InvoicePlane 1.6.3rc](https://github.com/InvoicePlane/InvoicePlane/blob/1749db329caf0a94fab018398cdbba66de1e1d3c/application/modules/upload/controllers/Upload.php#L118) adapted to Vvveb