### PR TITLE
Fix installer crash on macOS PHP-FPM and MySQL ANSI_QUOTES issues

### DIFF
--- a/install/sql/mysqli/schema/media/media_content.sql
+++ b/install/sql/mysqli/schema/media/media_content.sql
@@ -3,9 +3,9 @@ DROP TABLE IF EXISTS `media_content`;
 CREATE TABLE `media_content` (
   `media_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `language_id` INT UNSIGNED NOT NULL,
-  `name` varchar(191) NOT NULL DEFAULT "",
-  `caption` varchar(191) NOT NULL DEFAULT "",
-  `description` varchar(191) NOT NULL DEFAULT "",
+  `name` varchar(191) NOT NULL DEFAULT '',
+  `caption` varchar(191) NOT NULL DEFAULT '',
+  `description` varchar(191) NOT NULL DEFAULT '',
 --  `content` longtext,
   PRIMARY KEY (`media_id`,`language_id`),
 --  KEY `alt` (`alt`),

--- a/install/sql/mysqli/schema/post/post_content.sql
+++ b/install/sql/mysqli/schema/post/post_content.sql
@@ -3,12 +3,12 @@ DROP TABLE IF EXISTS `post_content`;
 CREATE TABLE `post_content` (
   `post_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `language_id` INT UNSIGNED NOT NULL,
-  `name` varchar(191) NOT NULL DEFAULT "",
-  `slug` varchar(191) NOT NULL DEFAULT "",
+  `name` varchar(191) NOT NULL DEFAULT '',
+  `slug` varchar(191) NOT NULL DEFAULT '',
   `content` longtext,
   `excerpt` text,
-  `meta_keywords` varchar(191) NOT NULL DEFAULT "",
-  `meta_description` varchar(191) NOT NULL DEFAULT "",
+  `meta_keywords` varchar(191) NOT NULL DEFAULT '',
+  `meta_description` varchar(191) NOT NULL DEFAULT '',
   PRIMARY KEY (`post_id`,`language_id`),
   KEY `slug` (`slug`),
   FULLTEXT `search` (`name`,`content`)

--- a/install/sql/mysqli/schema/product/product_content.sql
+++ b/install/sql/mysqli/schema/product/product_content.sql
@@ -3,13 +3,13 @@ DROP TABLE IF EXISTS `product_content`;
 CREATE TABLE `product_content` (
   `product_id` INT UNSIGNED NOT NULL,
   `language_id` INT UNSIGNED NOT NULL,
-  `name` varchar(191) NOT NULL DEFAULT "",
-  `slug` varchar(191) NOT NULL DEFAULT "",
+  `name` varchar(191) NOT NULL DEFAULT '',
+  `slug` varchar(191) NOT NULL DEFAULT '',
   `content` longtext,
   `excerpt` text,
-  `meta_title` varchar(191) NOT NULL DEFAULT "",
-  `meta_description` varchar(191) NOT NULL DEFAULT "",
-  `meta_keywords` varchar(191) NOT NULL DEFAULT "",
+  `meta_title` varchar(191) NOT NULL DEFAULT '',
+  `meta_description` varchar(191) NOT NULL DEFAULT '',
+  `meta_keywords` varchar(191) NOT NULL DEFAULT '',
   PRIMARY KEY (`product_id`,`language_id`),
   KEY `slug` (`slug`),
   FULLTEXT `search` (`name`,`content`)

--- a/system/db/mysqli.php
+++ b/system/db/mysqli.php
@@ -168,12 +168,14 @@ class Mysqli extends DBDriver {
 	 * Get all columns for a table used for sanitizing input
 	 */
 	function getColumnsMeta($tableName, $comment = false) {
+		$dbName    = addslashes((string)DB_NAME);
+		$tableName = addslashes((string)$tableName);
 		$sql =
 		'SELECT COLUMN_NAME as name, COLUMN_DEFAULT as d, IS_NULLABLE  as n, DATA_TYPE as t, EXTRA as e, CHARACTER_MAXIMUM_LENGTH as l'
 		. ($comment ? ', COLUMN_COMMENT as c' : '') .
 		' FROM `INFORMATION_SCHEMA`.`COLUMNS` 
-		WHERE `TABLE_SCHEMA`= "' . DB_NAME . '" 
-			AND `TABLE_NAME`="' . $tableName . '"';
+		WHERE `TABLE_SCHEMA`= \'' . $dbName . '\' 
+			AND `TABLE_NAME`=\'' . $tableName . '\'';
 
 		if ($result = $this->query($sql)) {
 			//$columns = $result->fetch_all(MYSQLI_ASSOC);

--- a/system/functions.php
+++ b/system/functions.php
@@ -502,7 +502,22 @@ function slugify($text, $divider = '-') {
 	return $text;
 }
 
-if ((!defined('GETTEXT') || GETTEXT == true) && function_exists('_')) {
+function useNativeGettext() {
+	$enabled = (!defined('GETTEXT') || GETTEXT == true) && function_exists('gettext');
+
+	if (! $enabled) {
+		return false;
+	}
+
+	// Work around PHP-FPM gettext/libintl crashes on macOS.
+	if (PHP_OS_FAMILY == 'Darwin' && PHP_SAPI == 'fpm-fcgi') {
+		return false;
+	}
+
+	return true;
+}
+
+if (useNativeGettext()) {
 	function __($text, $plural = false, $count = false, $nocache = false) {
 
 		if ($plural) {


### PR DESCRIPTION
## Summary
- Avoid native gettext path on macOS PHP-FPM to prevent SIGSEGV in libintl/gettext.
- Fix installer MySQL schema defaults (`DEFAULT ""` -> `DEFAULT ''`) for ANSI_QUOTES compatibility.
- Fix INFORMATION_SCHEMA metadata query quoting in mysqli driver.
## Reproduction
- Open `/install/index.php` on macOS + php-fpm.
- Previously got 502 / php-fpm SIGSEGV from gettext path.
- Installer also failed on MySQL with ANSI_QUOTES.
## Verification
- Installer page loads without php-fpm crash.
- Installation step proceeds without SQL 1064 / unknown column quoting errors.